### PR TITLE
Introduce field and entry as higher level helper on top of item.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphex"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A small librray to help creating command line tools exploring pseudo graph"
 authors = ["Matthieu Gautier <mgautier@kymeria.fr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "graphex"
 version = "0.2.0"
 edition = "2021"
-description = "A small librray to help creating command line tools exploring pseudo graph"
-authors = ["Matthieu Gautier <mgautier@kymeria.fr"]
+description = "A small library to help creating command line tools exploring pseudo graph"
+authors = ["Matthieu Gautier <mgautier@kymeria.fr>"]
 repository = "https://github.com/kymeria/graphex"
 license = "MIT"
 


### PR DESCRIPTION
This properly format header and value before using `item`.